### PR TITLE
Updated URL to match the keyDB domain change

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -183,7 +183,7 @@ std::vector<std::string> util_get_installed_tickets()
 
 void action_download()
 {
-	printf("Downloading 3ds.nfshost.com page...");
+	printf("Downloading 3ds.titlekeys.com page...");
 	
 	mkpath("/TIKdevil/", 0777);
 	mkpath("/TIKdevil/tickets/", 0777);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -188,7 +188,7 @@ void action_download()
 	mkpath("/TIKdevil/", 0777);
 	mkpath("/TIKdevil/tickets/", 0777);
 	FILE *oh = fopen("/TIKdevil/fullpage", "wb");
-	Result sres = DownloadFile("http://3ds.nfshost.com/", oh, true);
+	Result sres = DownloadFile("http://3ds.titlekeys.com/", oh, true);
 	fclose(oh);
 	if (sres != 0)
 	{


### PR DESCRIPTION
Updated the 3ds.nfshost.com link to 3ds.titlekeys.com to facilitate proper program function.
